### PR TITLE
Add animated bubble background and enhance hero transitions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,10 +7,12 @@ import Competences from './components/Competences.jsx';
 import Projects from './components/Projects.jsx';
 import Contact from './components/Contact.jsx';
 import Footer from './components/Footer.jsx';
+import AnimatedBackground from './components/AnimatedBackground.jsx';
 
 export default function App() {
   return (
     <>
+      <AnimatedBackground />
       <Navbar />
       <Hero />
       <Competences />

--- a/src/components/AnimatedBackground.jsx
+++ b/src/components/AnimatedBackground.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+export default function AnimatedBackground() {
+  const bubbles = [
+    { size: 'w-16 h-16', left: '10%', delay: '0s' },
+    { size: 'w-24 h-24', left: '20%', delay: '3s' },
+    { size: 'w-12 h-12', left: '30%', delay: '6s' },
+    { size: 'w-20 h-20', left: '40%', delay: '9s' },
+    { size: 'w-16 h-16', left: '60%', delay: '12s' },
+    { size: 'w-28 h-28', left: '70%', delay: '15s' },
+    { size: 'w-14 h-14', left: '80%', delay: '18s' },
+    { size: 'w-18 h-18', left: '90%', delay: '21s' }
+  ];
+
+  return (
+    <div className="fixed inset-0 z-0 pointer-events-none hidden md:block">
+      {bubbles.map((b, i) => (
+        <div
+          key={i}
+          className={`bubble ${b.size}`}
+          style={{ left: b.left, animationDelay: b.delay }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -24,7 +24,7 @@ export default function Hero() {
             </a>
             <a
               href="#contact"
-              className="border-2 border-primary-red px-6 sm:px-8 py-3 sm:py-4 rounded-lg text-base sm:text-lg font-semibold hover:bg-primary-red transition"
+              className="border-2 border-primary-red px-6 sm:px-8 py-3 sm:py-4 rounded-lg text-base sm:text-lg font-semibold hover:bg-primary-red transition transform hover:scale-105"
             >
               Me contacter
             </a>


### PR DESCRIPTION
## Summary
- add animated bubble background component with floating bubbles
- integrate background into app layout
- refine hero call-to-action buttons with transition and scale effects

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b83f0bd41c832dbe846e9ebf22184c