### PR TITLE
feat: enable bubble animation on mobile

### DIFF
--- a/src/components/AnimatedBackground.jsx
+++ b/src/components/AnimatedBackground.jsx
@@ -13,7 +13,7 @@ export default function AnimatedBackground() {
   ];
 
   return (
-    <div className="fixed inset-0 z-0 pointer-events-none hidden md:block">
+    <div className="fixed inset-0 z-0 pointer-events-none">
       {bubbles.map((b, i) => (
         <div
           key={i}


### PR DESCRIPTION
## Summary
- display bubble background on all screen sizes so animation appears on mobile

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b840592d70832d99668300003a4e66