### PR TITLE
feat: full-screen mobile menu and visible WhatsApp button

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -51,7 +51,7 @@ export default function Navbar() {
       </div>
 
       <div
-        className={`fixed top-0 right-0 h-full w-64 bg-black/95 backdrop-blur-md transform transition-transform duration-300 md:hidden ${open ? 'translate-x-0' : 'translate-x-full'}`}
+        className={`fixed top-0 left-0 h-screen w-screen bg-black transform transition-transform duration-300 md:hidden ${open ? 'translate-x-0' : 'translate-x-full'}`}
       >
         <div className="pt-20 px-6">
           <ul className="space-y-6">

--- a/src/index.css
+++ b/src/index.css
@@ -83,7 +83,7 @@
   position: fixed;
   bottom: 20px;
   right: 20px;
-  z-index: 1000;
+  z-index: 1200;
   background: #25d366;
   border-radius: 50%;
   width: 60px;


### PR DESCRIPTION
## Summary
- expand mobile menu to full-screen with an opaque black background
- raise floating WhatsApp button above navigation overlay

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b842c9ae10832d858224b9fb47b753