### PR TITLE
Fix delayed project image loading

### DIFF
--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -28,6 +28,7 @@ export default function Projects() {
                 <img
                   src={project.image}
                   alt={project.name}
+                  loading="eager"
                   className="w-full h-48 sm:h-64 object-cover"
                 />
                 <div className="absolute inset-0 bg-gradient-to-t from-black/80 to-transparent"></div>
@@ -76,6 +77,7 @@ export default function Projects() {
                 <img
                   src={selectedProject.image}
                   alt={selectedProject.name}
+                  loading="eager"
                   className="w-full rounded-lg mb-4 sm:mb-6"
                 />
                 <div className="flex flex-wrap gap-2 mb-4 sm:mb-6">


### PR DESCRIPTION
## Summary
- load project card images eagerly so they appear immediately when the page opens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b85f4da1e8832d8eb16565098f7b4d