### PR TITLE
feat: add mobile popup close button

### DIFF
--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -138,6 +138,12 @@ export default function Projects() {
                 >
                   Voir le site <i className="fas fa-external-link-alt ml-2"></i>
                 </a>
+                <button
+                  onClick={() => setSelectedProject(null)}
+                  className="mt-4 w-full sm:hidden bg-gray-700 px-4 py-2 rounded-lg text-white hover:bg-gray-600 transition text-sm"
+                >
+                  {t('projects.close')}
+                </button>
               </div>
             </div>
           </div>

--- a/src/data/translations.js
+++ b/src/data/translations.js
@@ -27,7 +27,7 @@ export const translations = {
         { icon: 'fa-js-square', title: 'JavaScript', text: 'Interactivité', delay: '1s' }
       ]
     },
-    projects: { title: { part1: 'Mes', part2: 'Réalisations' } },
+    projects: { title: { part1: 'Mes', part2: 'Réalisations' }, close: 'Fermer' },
     contact: {
       title: { part1: 'Me', part2: 'Contacter' },
       infoTitle: 'Informations de contact',
@@ -78,7 +78,7 @@ export const translations = {
         { icon: 'fa-js-square', title: 'JavaScript', text: 'Interactivity', delay: '1s' }
       ]
     },
-    projects: { title: { part1: 'My', part2: 'Projects' } },
+    projects: { title: { part1: 'My', part2: 'Projects' }, close: 'Close' },
     contact: {
       title: { part1: 'Contact', part2: 'Me' },
       infoTitle: 'Contact Information',


### PR DESCRIPTION
## Summary
- add mobile-only close button for project detail modal
- localize close button text in translations

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b860bec8c4832daf4eca3b2b5376dc