### PR TITLE
Optimise le chargement mobile en supprimant FontAwesome

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,19 +32,7 @@
     <meta name="twitter:site" content="@SiteOnWeb" />
     <link rel="icon" href="/favicon.ico" />
     <title>SiteOnWeb - Développeur Web Professionnel</title>
-    <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin />
-    <link
-      rel="preload"
-      as="style"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
-      onload="this.onload=null;this.rel='stylesheet'"
-    />
-    <noscript>
-      <link
-        rel="stylesheet"
-        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
-      />
-    </noscript>
+    <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin />
     <!-- Google Tag Manager -->
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -55,8 +43,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   </head>
   <body class="bg-dark-bg text-white">
     <!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5SBG3VBW"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5SBG3VBW" height="0" width="0" style="display:none;visibility:hidden" loading="lazy" title="Google Tag Manager"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
     <a
       href="https://wa.me/33648456937"
@@ -66,7 +53,18 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       aria-label="Contactez-moi sur WhatsApp"
       rel="noopener noreferrer"
     >
-      <i class="fab fa-whatsapp text-white text-2xl"></i>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        class="w-8 h-8 text-white"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <path
+          fill="currentColor"
+          d="M16.7 13.5c-.5-.2-1-.1-1.4.3l-.9.9c-1.6-.8-3-2.1-3.8-3.8l.9-.9c.4-.4.5-.9.3-1.4l-1.1-2.6c-.2-.5-.7-.8-1.2-.8h-2c-.7 0-1.3.6-1.3 1.3 0 7 5.7 12.7 12.7 12.7.7 0 1.3-.6 1.3-1.3v-2c0-.5-.3-1-.8-1.2l-2.7-1.1z"
+        />
+      </svg>
     </a>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>


### PR DESCRIPTION
## Summary
- remplace FontAwesome par une icône WhatsApp inline pour éviter les ressources de blocage
- préconnecte Google Tag Manager et charge l'iframe en différé

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9e03d6e3c832da73d88e2536b935e