### PR TITLE
fix: update Gold Assurance link

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -10,6 +10,7 @@ export const projects = [
       en: 'Screenshot of the Gold Assurance dashboard'
     },
     image: 'images/gold-assurance.png',
+    url: 'https://www.goldassurance.fr/home',
     tags: {
       fr: ['React', 'Node.js', 'Dashboard'],
       en: ['React', 'Node.js', 'Dashboard']


### PR DESCRIPTION
## Summary
- add Gold Assurance site URL so project link works

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c59fb64a50832d8f085846f5c95bb1