### PR TITLE
fix: show close symbol for project details

### DIFF
--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -65,10 +65,10 @@ export default function Projects() {
           >
             <button
               onClick={() => setSelectedProject(null)}
-              className="absolute top-4 right-4 text-gray-400 hover:text-white text-xl sm:text-2xl"
+              className="absolute top-4 right-4 text-gray-400 hover:text-white text-2xl sm:text-3xl"
               aria-label={t('projects.close')}
             >
-              <i className="fas fa-times"></i>
+              ×
             </button>
             <div className="mb-4 sm:mb-6">
               <h3 className="text-xl sm:text-3xl font-bold text-white">


### PR DESCRIPTION
## Summary
- replace removed Font Awesome cross with text symbol so project details overlay can be closed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5a521b5fc832db387967f9579b12c