### PR TITLE
Display full language names in navbar

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -52,8 +52,8 @@ export default function Navbar() {
             onChange={(e) => setLang(e.target.value)}
             className="bg-black text-white border border-primary-red rounded px-2 py-1"
           >
-            <option value="fr">FR</option>
-            <option value="en">EN</option>
+            <option value="fr">Français</option>
+            <option value="en">English</option>
           </select>
           <button className="md:hidden text-white z-50" onClick={toggle}>
             <span className="text-xl">{open ? '✖' : '☰'}</span>
@@ -74,8 +74,8 @@ export default function Navbar() {
               }}
               className="w-full bg-black text-white border border-primary-red rounded px-2 py-1"
             >
-              <option value="fr">FR</option>
-              <option value="en">EN</option>
+              <option value="fr">Français</option>
+              <option value="en">English</option>
             </select>
           </div>
           <ul className="space-y-6">


### PR DESCRIPTION
## Summary
- Show `Français` and `English` instead of `FR`/`EN` in navbar language selector

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5aa660d38832d8cf1cceb76a8ae9e