### PR TITLE
feat: add custom Open Graph image

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,13 +22,15 @@
     <meta property="og:description" content="Développeur web professionnel spécialisé dans la création de sites modernes, performants et optimisés." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://siteonweb.fr/" />
-    <meta property="og:image" content="https://picsum.photos/600/315?random=999" />
+    <meta property="og:image" content="https://siteonweb.fr/images/og-image.svg" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:locale" content="fr_FR" />
     <meta property="og:site_name" content="SiteOnWeb" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="SiteOnWeb - Développeur Web Professionnel" />
     <meta name="twitter:description" content="Développeur web professionnel spécialisé dans la création de sites modernes, performants et optimisés." />
-    <meta name="twitter:image" content="https://picsum.photos/600/315?random=999" />
+    <meta name="twitter:image" content="https://siteonweb.fr/images/og-image.svg" />
     <meta name="twitter:site" content="@SiteOnWeb" />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <!-- External icon fonts removed to avoid dependency on blocked CDNs -->

--- a/public/images/og-image.svg
+++ b/public/images/og-image.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <rect width="1200" height="630" fill="#000000"/>
+  <g transform="translate(450,165)">
+    <rect width="300" height="300" rx="56" ry="56" fill="#ec1c24"/>
+    <text x="150" y="205" text-anchor="middle" font-size="200" fill="#ffffff" font-family="Arial, Helvetica, sans-serif">S</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- add Open Graph preview image with logo centered on black background
- reference the new image in Open Graph and Twitter meta tags

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5ada4b7a4832d8b96ee4742231319