### PR TITLE
feat: add typing animation to hero title

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useLanguage } from '../LanguageContext.jsx';
+import TypingText from './TypingText.jsx';
 
 export default function Hero() {
   const { t } = useLanguage();
@@ -8,7 +9,7 @@ export default function Hero() {
       <div className="container mx-auto text-center">
         <div className="animate-slide-up">
           <h1 className="text-4xl sm:text-6xl md:text-8xl font-bold mb-4 sm:mb-6 hero-text leading-tight">
-            {t('hero.title')}
+            <TypingText text={t('hero.title')} />
           </h1>
           <h2 className="text-xl sm:text-3xl md:text-4xl font-light mb-6 sm:mb-8 text-gray-300">
             {t('hero.subtitle')}

--- a/src/components/TypingText.jsx
+++ b/src/components/TypingText.jsx
@@ -1,0 +1,25 @@
+import React, { useState, useEffect } from 'react';
+
+export default function TypingText({ text, speed = 100, pause = 5000 }) {
+  const [displayed, setDisplayed] = useState('');
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    if (index < text.length) {
+      const timeout = setTimeout(() => {
+        setDisplayed((prev) => prev + text.charAt(index));
+        setIndex((prev) => prev + 1);
+      }, speed);
+      return () => clearTimeout(timeout);
+    } else {
+      const timeout = setTimeout(() => {
+        setDisplayed('');
+        setIndex(0);
+      }, pause);
+      return () => clearTimeout(timeout);
+    }
+  }, [index, text, speed, pause]);
+
+  return <span className="typing">{displayed}</span>;
+}
+

--- a/src/index.css
+++ b/src/index.css
@@ -108,3 +108,18 @@
     right: 15px;
   }
 }
+
+@keyframes blink {
+  0%, 49% {
+    opacity: 1;
+  }
+  50%, 100% {
+    opacity: 0;
+  }
+}
+
+.typing::after {
+  content: '|';
+  animation: blink 1s step-start infinite;
+  margin-left: 2px;
+}


### PR DESCRIPTION
## Summary
- add TypingText component that types and resets text
- use TypingText in Hero title for looping typing effect
- style typing cursor animation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5b1df29c4832dae23a28986116583