### PR TITLE
feat: add typing animation component and navbar logo animation

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useLanguage } from '../LanguageContext.jsx';
+import TypingText from './TypingText.jsx';
 
 export default function Navbar() {
   const [open, setOpen] = useState(false);
@@ -19,7 +20,7 @@ export default function Navbar() {
       <div className="container mx-auto px-4 sm:px-6 py-4 flex justify-between items-center">
         <a href="#accueil" className="flex items-center space-x-3">
           <div className="w-8 h-8 sm:w-10 sm:h-10 bg-gradient-to-r from-primary-red to-red-500 rounded-lg flex items-center justify-center">
-            <span className="text-white text-sm sm:text-lg">&lt;/&gt;</span>
+            <TypingText text={"</>"} className="text-white text-sm sm:text-lg" />
           </div>
           <span className="text-xl sm:text-2xl font-bold text-white">SiteOnWeb</span>
         </a>

--- a/src/components/TypingText.jsx
+++ b/src/components/TypingText.jsx
@@ -1,0 +1,25 @@
+import React, { useState, useEffect } from 'react';
+
+export default function TypingText({ text, speed = 200, pause = 5000, className = '' }) {
+  const [displayed, setDisplayed] = useState('');
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    if (index < text.length) {
+      const timeout = setTimeout(() => {
+        setDisplayed((prev) => prev + text.charAt(index));
+        setIndex((prev) => prev + 1);
+      }, speed);
+      return () => clearTimeout(timeout);
+    } else {
+      const timeout = setTimeout(() => {
+        setDisplayed('');
+        setIndex(0);
+      }, pause);
+      return () => clearTimeout(timeout);
+    }
+  }, [index, text, speed, pause]);
+
+  return <span className={`typing ${className}`.trim()}>{displayed}</span>;
+}
+

--- a/src/index.css
+++ b/src/index.css
@@ -108,3 +108,24 @@
     right: 15px;
   }
 }
+
+@keyframes blink {
+  0%, 49% {
+    opacity: 1;
+  }
+  50%, 100% {
+    opacity: 0;
+  }
+}
+
+.typing {
+  display: inline-block;
+  width: 100%;
+  text-align: center;
+}
+
+.typing::after {
+  content: '|';
+  animation: blink 1s step-start infinite;
+  margin-left: 2px;
+}


### PR DESCRIPTION
## Summary
- add TypingText component that types and resets text
- animate navbar logo while keeping hero title static
- style typing cursor animation
- center typing output and slow default typing speed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5b1df29c4832dae23a28986116583