### PR TITLE
Replace typing effect with CSS animation

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useLanguage } from '../LanguageContext.jsx';
-import TypingText from './TypingText.jsx';
 
 export default function Hero() {
   const { t } = useLanguage();
@@ -9,7 +8,9 @@ export default function Hero() {
       <div className="container mx-auto text-center">
         <div className="animate-slide-up">
           <h1 className="text-4xl sm:text-6xl md:text-8xl font-bold mb-4 sm:mb-6 hero-text leading-tight">
-            <TypingText text={t('hero.title')} />
+            <span className="typing-text typing-text--animate hero-text__content">
+              {t('hero.title')}
+            </span>
           </h1>
           <h2 className="text-xl sm:text-3xl md:text-4xl font-light mb-6 sm:mb-8 text-gray-300">
             {t('hero.subtitle')}

--- a/src/components/TypingText.jsx
+++ b/src/components/TypingText.jsx
@@ -1,28 +1,14 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 
+export default function TypingText({ text, className = '', animate = true }) {
+  const classes = [
+    'typing-text',
+    animate ? 'typing-text--animate' : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
 
-export default function TypingText({ text, speed = 200, pause = 5000, className = '' }) {
-
-
-  const [displayed, setDisplayed] = useState('');
-  const [index, setIndex] = useState(0);
-
-  useEffect(() => {
-    if (index < text.length) {
-      const timeout = setTimeout(() => {
-        setDisplayed((prev) => prev + text.charAt(index));
-        setIndex((prev) => prev + 1);
-      }, speed);
-      return () => clearTimeout(timeout);
-    } else {
-      const timeout = setTimeout(() => {
-        setDisplayed('');
-        setIndex(0);
-      }, pause);
-      return () => clearTimeout(timeout);
-    }
-  }, [index, text, speed, pause]);
-
-  return <span className={`typing ${className}`.trim()}>{displayed}</span>;
+  return <span className={classes}>{text}</span>;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -132,24 +132,34 @@
   }
 }
 
-@keyframes blink {
-  0%, 49% {
-    opacity: 1;
+@keyframes typing-reveal {
+  from {
+    clip-path: inset(0 100% 0 0);
   }
-  50%, 100% {
-    opacity: 0;
+  to {
+    clip-path: inset(0 0 0 0);
   }
 }
 
-.typing {
+.typing-text {
   display: inline-block;
-  width: 100%;
-  text-align: center;
+  white-space: inherit;
 }
 
+.typing-text--animate {
+  --typing-duration: 2.6s;
+  clip-path: inset(0 100% 0 0);
+  animation: typing-reveal var(--typing-duration) steps(40, end) forwards;
+}
 
-.typing::after {
-  content: '|';
-  animation: blink 1s step-start infinite;
-  margin-left: 2px;
+.hero-text__content {
+  --typing-duration: 2.8s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .typing-text--animate,
+  .hero-text__content {
+    clip-path: none;
+    animation: none;
+  }
 }


### PR DESCRIPTION
## Summary
- render the hero title directly from the translation context instead of the TypingText component
- simplify TypingText to return static markup and rely on CSS-only masking for the reveal effect
- replace the JavaScript typing styles with a CSS animation that honors prefers-reduced-motion

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de6bd62e94832db20f1948d36ecd1b