### PR TITLE
Restore hero typewriter animation with CSS

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,21 +1,30 @@
 import React from 'react';
 import { useLanguage } from '../LanguageContext.jsx';
-import TypingText from './TypingText.jsx';
 
 export default function Hero() {
   const { t } = useLanguage();
+  const heroTitle = t('hero.title');
+  const heroSubtitle = t('hero.subtitle');
+  const heroDescription = t('hero.description');
+  const heroTitleWidth = `calc(${Math.max(heroTitle.length, 1)}ch + 0.5ch)`;
+
   return (
     <section id="accueil" className="min-h-screen flex items-center justify-center relative z-10 px-4">
       <div className="container mx-auto text-center">
         <div className="animate-slide-up">
           <h1 className="text-4xl sm:text-6xl md:text-8xl font-bold mb-4 sm:mb-6 hero-text leading-tight">
-            <TypingText text={t('hero.title')} />
+            <span
+              className="typing-text typing-text--animate hero-text__content"
+              style={{ '--typing-target-width': heroTitleWidth }}
+            >
+              {heroTitle}
+            </span>
           </h1>
           <h2 className="text-xl sm:text-3xl md:text-4xl font-light mb-6 sm:mb-8 text-gray-300">
-            {t('hero.subtitle')}
+            {heroSubtitle}
           </h2>
           <p className="text-base sm:text-xl text-gray-400 max-w-3xl mx-auto mb-8 sm:mb-12 leading-relaxed px-4">
-            {t('hero.description')}
+            {heroDescription}
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center px-4">
             <a

--- a/src/components/TypingText.jsx
+++ b/src/components/TypingText.jsx
@@ -1,28 +1,22 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 
+export default function TypingText({ text, className = '', animate = false }) {
+  const classes = [
+    'typing-text',
+    animate ? 'typing-text--animate' : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
 
-export default function TypingText({ text, speed = 200, pause = 5000, className = '' }) {
+  const style = animate
+    ? { '--typing-target-width': `calc(${Math.max(text.length, 1)}ch + 0.5ch)` }
+    : undefined;
 
-
-  const [displayed, setDisplayed] = useState('');
-  const [index, setIndex] = useState(0);
-
-  useEffect(() => {
-    if (index < text.length) {
-      const timeout = setTimeout(() => {
-        setDisplayed((prev) => prev + text.charAt(index));
-        setIndex((prev) => prev + 1);
-      }, speed);
-      return () => clearTimeout(timeout);
-    } else {
-      const timeout = setTimeout(() => {
-        setDisplayed('');
-        setIndex(0);
-      }, pause);
-      return () => clearTimeout(timeout);
-    }
-  }, [index, text, speed, pause]);
-
-  return <span className={`typing ${className}`.trim()}>{displayed}</span>;
+  return (
+    <span className={classes} style={style}>
+      {text}
+    </span>
+  );
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -132,24 +132,68 @@
   }
 }
 
-@keyframes blink {
-  0%, 49% {
+@keyframes typing {
+  from {
+    max-width: 0;
+  }
+  to {
+    max-width: var(--typing-target-width, 100%);
+  }
+}
+
+@keyframes caret {
+  0%,
+  50% {
     opacity: 1;
   }
-  50%, 100% {
+  50.01%,
+  100% {
     opacity: 0;
   }
 }
 
-.typing {
+.typing-text {
+  position: relative;
   display: inline-block;
-  width: 100%;
-  text-align: center;
+  white-space: nowrap;
 }
 
+.typing-text--animate {
+  --typing-duration: 2.6s;
+  overflow: hidden;
+  padding-right: 0.25em;
+  max-width: 0;
+  animation: typing var(--typing-duration) steps(40, end) forwards;
+}
 
-.typing::after {
-  content: '|';
-  animation: blink 1s step-start infinite;
-  margin-left: 2px;
+.typing-text--animate::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: 0.12em;
+  background: rgba(255, 255, 255, 0.85);
+  animation: caret 0.8s steps(1, end) infinite;
+}
+
+.hero-text__content {
+  background: linear-gradient(45deg, #ffffff, #dc2626);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  --typing-duration: 2.8s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .typing-text--animate {
+    max-width: none;
+    animation: none;
+    overflow: visible;
+  }
+
+  .typing-text--animate::after {
+    animation: none;
+    opacity: 0;
+  }
 }


### PR DESCRIPTION
## Summary
- render the hero title directly from the translation context instead of the TypingText component
- compute the hero heading dimensions in React so the CSS-only typewriter animation can reveal the full text and caret again
- refresh the typing styles to animate max-width with a blinking caret while still honoring prefers-reduced-motion

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de6bd62e94832db20f1948d36ecd1b