### PR TITLE
Fix mobile CSS block that broke hero animation

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -124,6 +124,14 @@
     right: 15px;
   }
 
+  .github-float {
+    width: 50px;
+    height: 50px;
+    bottom: 75px;
+    right: 15px;
+  }
+}
+
 @keyframes typing-reveal {
   from {
     clip-path: inset(0 100% 0 0);


### PR DESCRIPTION
## Summary
- close the missing mobile media query so PostCSS can parse index.css again
- adjust the floating action buttons for smaller screens while restoring the hero animation styles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de73776d34832dbf02df01411cfa5d