### PR TITLE
Remove GitHub button from public pages

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -31,29 +31,6 @@
     <title>Blog - SiteOnWeb | Conseils & Guides pour votre Site Web</title>
   </head>
   <body class="bg-dark-bg text-white">
-    <!-- Bouton GitHub flottant -->
-    <a
-      href="https://github.com/Niabag"
-      target="_blank"
-      class="github-float"
-      title="Voir mon profil GitHub"
-      aria-label="Voir mon profil GitHub"
-      rel="noopener noreferrer"
-    >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 24 24"
-        class="w-8 h-8 text-white"
-        aria-hidden="true"
-        focusable="false"
-      >
-        <path
-          fill="currentColor"
-          d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.6.113.82-.26.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.386-1.332-1.755-1.332-1.755-1.087-.744.084-.729.084-.729 1.205.085 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.108-.776.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.574C20.565 21.795 24 17.295 24 12c0-6.627-5.373-12-12-12z"
-        />
-      </svg>
-    </a>
-
     <!-- Bouton WhatsApp flottant -->
     <a
       href="https://wa.me/33648456937"

--- a/faq.html
+++ b/faq.html
@@ -57,29 +57,6 @@
     <title>FAQ - SiteOnWeb | Questions Fréquentes sur nos Services Web</title>
   </head>
   <body class="bg-dark-bg text-white">
-    <!-- Bouton GitHub flottant -->
-    <a
-      href="https://github.com/Niabag"
-      target="_blank"
-      class="github-float"
-      title="Voir mon profil GitHub"
-      aria-label="Voir mon profil GitHub"
-      rel="noopener noreferrer"
-    >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 24 24"
-        class="w-8 h-8 text-white"
-        aria-hidden="true"
-        focusable="false"
-      >
-        <path
-          fill="currentColor"
-          d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.6.113.82-.26.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.386-1.332-1.755-1.332-1.755-1.087-.744.084-.729.084-.729 1.205.085 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.108-.776.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.574C20.565 21.795 24 17.295 24 12c0-6.627-5.373-12-12-12z"
-        />
-      </svg>
-    </a>
-
     <!-- Bouton WhatsApp flottant -->
     <a
       href="https://wa.me/33648456937"

--- a/index.html
+++ b/index.html
@@ -53,29 +53,6 @@
     <title>SiteOnWeb - Création de sites web sur-mesure pour booster votre entreprise en ligne</title>
   </head>
   <body class="bg-dark-bg text-white">
-    <!-- Bouton GitHub flottant -->
-    <a
-      href="https://github.com/Niabag"
-      target="_blank"
-      class="github-float"
-      title="Voir mon profil GitHub"
-      aria-label="Voir mon profil GitHub"
-      rel="noopener noreferrer"
-    >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 24 24"
-        class="w-8 h-8 text-white"
-        aria-hidden="true"
-        focusable="false"
-      >
-        <path
-          fill="currentColor"
-          d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.6.113.82-.26.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.386-1.332-1.755-1.332-1.755-1.087-.744.084-.729.084-.729 1.205.085 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.108-.776.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.574C20.565 21.795 24 17.295 24 12c0-6.627-5.373-12-12-12z"
-        />
-      </svg>
-    </a>
-
     <!-- Bouton WhatsApp flottant -->
     <a
       href="https://wa.me/33648456937"

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -42,14 +42,6 @@ export default function Footer() {
                 <i className="fab fa-linkedin text-lg sm:text-xl"></i>
               </a>
               <a
-                href="https://github.com/Niabag"
-                target="_blank"
-                className="text-gray-400 hover:text-primary-red transition"
-                title="GitHub"
-              >
-                <i className="fab fa-github text-lg sm:text-xl"></i>
-              </a>
-              <a
                 href="https://wa.me/33648456937"
                 target="_blank"
                 className="text-gray-400 hover:text-primary-red transition"

--- a/src/index.css
+++ b/src/index.css
@@ -71,29 +71,6 @@
   box-shadow: 0 15px 30px rgba(220,38,38,0.4);
 }
 
-/* GitHub floating button */
-.github-float {
-  position: fixed;
-  bottom: 90px;
-  right: 20px;
-  z-index: 1200;
-  background: #333;
-  border-radius: 50%;
-  width: 60px;
-  height: 60px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
-  transition: all 0.3s ease;
-  animation: pulse 2s infinite;
-}
-.github-float:hover {
-  transform: scale(1.1);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.6);
-  background: #444;
-}
-
 /* WhatsApp floating button */
 .whatsapp-float {
   position: fixed;
@@ -121,13 +98,6 @@
     width: 50px;
     height: 50px;
     bottom: 15px;
-    right: 15px;
-  }
-
-  .github-float {
-    width: 50px;
-    height: 50px;
-    bottom: 75px;
     right: 15px;
   }
 }


### PR DESCRIPTION
## Summary
- remove the floating GitHub button from the public HTML pages
- delete the unused GitHub styles and footer link

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68debfd81914832d868c52b0df6c17de