### PR TITLE
Ensure contact form emails reach the contact inbox

### DIFF
--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useLanguage } from '../LanguageContext.jsx';
 
 const emailRegex = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
+const RECIPIENT_EMAIL = 'contact@siteonweb.fr';
 
 export default function Contact() {
   const { t } = useLanguage();
@@ -33,8 +34,16 @@ const onSubmit = async (event) => {
   }
 
   const formData = new FormData(event.target);
-  // ... vérif email comme tu fais déjà
+  const visitorEmail = formData.get('email');
+
+  if (!visitorEmail || !emailRegex.test(visitorEmail)) {
+    setResult(t('contact.invalidEmail'));
+    return;
+  }
+
   formData.append('access_key', accessKey);
+  formData.set('email', RECIPIENT_EMAIL);
+  formData.set('reply_to', visitorEmail);
 
     try {
       const response = await fetch('https://api.web3forms.com/submit', {

--- a/src/data/translations.js
+++ b/src/data/translations.js
@@ -40,7 +40,8 @@ export const translations = {
       messagePlaceholder: 'Votre message',
       send: 'Envoyer le message',
       whatsapp: 'WhatsApp: 06 48 45 69 37',
-      country: 'France'
+      country: 'France',
+      invalidEmail: 'Adresse e-mail invalide.'
     },
     footer: {
       description:
@@ -182,7 +183,8 @@ export const translations = {
       messagePlaceholder: 'Your message',
       send: 'Send message',
       whatsapp: 'WhatsApp: +33 6 48 45 69 37',
-      country: 'France'
+      country: 'France',
+      invalidEmail: 'Invalid email address.'
     },
     footer: {
       description:


### PR DESCRIPTION
## Summary
- ensure Web3Forms submissions target contact@siteonweb.fr while keeping the visitor email as reply-to
- validate visitor email before submitting and surface a localized error message
- add translation entries for the new validation feedback in both languages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ded8bd43e0832d98aeb410bf11ca2d