### PR TITLE
Add floating Instagram contact button

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -31,6 +31,28 @@
     <title>Blog - SiteOnWeb | Conseils & Guides pour votre Site Web</title>
   </head>
   <body class="bg-dark-bg text-white">
+    <!-- Boutons sociaux flottants -->
+    <a
+      href="https://www.instagram.com/siteonweb/"
+      target="_blank"
+      class="instagram-float"
+      title="Suivez-moi sur Instagram"
+      aria-label="Suivez-moi sur Instagram"
+      rel="noopener noreferrer"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        class="w-8 h-8 text-white"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <path
+          fill="currentColor"
+          d="M7 2C4.243 2 2 4.243 2 7v10c0 2.757 2.243 5 5 5h10c2.757 0 5-2.243 5-5V7c0-2.757-2.243-5-5-5H7zm0 2h10c1.654 0 3 1.346 3 3v10c0 1.654-1.346 3-3 3H7c-1.654 0-3-1.346-3-3V7c0-1.654 1.346-3 3-3zm10.5 1a1.5 1.5 0 0 0-1.06 2.56A1.5 1.5 0 1 0 17.5 5zm-5.5 2C9.467 7 7 9.467 7 12.5S9.467 18 12.5 18s5.5-2.467 5.5-5.5S15.533 7 12.5 7zm0 2c1.93 0 3.5 1.57 3.5 3.5S14.43 16 12.5 16 9 14.43 9 12.5 10.57 9 12.5 9z"
+        />
+      </svg>
+    </a>
     <!-- Bouton WhatsApp flottant -->
     <a
       href="https://wa.me/33648456937"

--- a/faq.html
+++ b/faq.html
@@ -57,6 +57,28 @@
     <title>FAQ - SiteOnWeb | Questions Fréquentes sur nos Services Web</title>
   </head>
   <body class="bg-dark-bg text-white">
+    <!-- Boutons sociaux flottants -->
+    <a
+      href="https://www.instagram.com/siteonweb/"
+      target="_blank"
+      class="instagram-float"
+      title="Suivez-moi sur Instagram"
+      aria-label="Suivez-moi sur Instagram"
+      rel="noopener noreferrer"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        class="w-8 h-8 text-white"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <path
+          fill="currentColor"
+          d="M7 2C4.243 2 2 4.243 2 7v10c0 2.757 2.243 5 5 5h10c2.757 0 5-2.243 5-5V7c0-2.757-2.243-5-5-5H7zm0 2h10c1.654 0 3 1.346 3 3v10c0 1.654-1.346 3-3 3H7c-1.654 0-3-1.346-3-3V7c0-1.654 1.346-3 3-3zm10.5 1a1.5 1.5 0 0 0-1.06 2.56A1.5 1.5 0 1 0 17.5 5zm-5.5 2C9.467 7 7 9.467 7 12.5S9.467 18 12.5 18s5.5-2.467 5.5-5.5S15.533 7 12.5 7zm0 2c1.93 0 3.5 1.57 3.5 3.5S14.43 16 12.5 16 9 14.43 9 12.5 10.57 9 12.5 9z"
+        />
+      </svg>
+    </a>
     <!-- Bouton WhatsApp flottant -->
     <a
       href="https://wa.me/33648456937"

--- a/index.html
+++ b/index.html
@@ -53,6 +53,28 @@
     <title>SiteOnWeb - Création de sites web sur-mesure pour booster votre entreprise en ligne</title>
   </head>
   <body class="bg-dark-bg text-white">
+    <!-- Boutons sociaux flottants -->
+    <a
+      href="https://www.instagram.com/siteonweb/"
+      target="_blank"
+      class="instagram-float"
+      title="Suivez-moi sur Instagram"
+      aria-label="Suivez-moi sur Instagram"
+      rel="noopener noreferrer"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        class="w-8 h-8 text-white"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <path
+          fill="currentColor"
+          d="M7 2C4.243 2 2 4.243 2 7v10c0 2.757 2.243 5 5 5h10c2.757 0 5-2.243 5-5V7c0-2.757-2.243-5-5-5H7zm0 2h10c1.654 0 3 1.346 3 3v10c0 1.654-1.346 3-3 3H7c-1.654 0-3-1.346-3-3V7c0-1.654 1.346-3 3-3zm10.5 1a1.5 1.5 0 0 0-1.06 2.56A1.5 1.5 0 1 0 17.5 5zm-5.5 2C9.467 7 7 9.467 7 12.5S9.467 18 12.5 18s5.5-2.467 5.5-5.5S15.533 7 12.5 7zm0 2c1.93 0 3.5 1.57 3.5 3.5S14.43 16 12.5 16 9 14.43 9 12.5 10.57 9 12.5 9z"
+        />
+      </svg>
+    </a>
     <!-- Bouton WhatsApp flottant -->
     <a
       href="https://wa.me/33648456937"

--- a/src/index.css
+++ b/src/index.css
@@ -71,7 +71,7 @@
   box-shadow: 0 15px 30px rgba(220,38,38,0.4);
 }
 
-/* WhatsApp floating button */
+/* Floating social buttons */
 .whatsapp-float {
   position: fixed;
   bottom: 20px;
@@ -93,11 +93,40 @@
   box-shadow: 0 6px 20px rgba(37, 211, 102, 0.6);
 }
 
+.instagram-float {
+  position: fixed;
+  bottom: 90px;
+  right: 20px;
+  z-index: 1200;
+  background: radial-gradient(circle at 30% 30%, #fdf497 0%, #fdf497 5%, #fd5949 45%, #d6249f 60%, #285aeb 90%);
+  border-radius: 50%;
+  width: 60px;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 12px rgba(214, 36, 159, 0.45);
+  transition: all 0.3s ease;
+  animation: pulse 2s infinite;
+}
+
+.instagram-float:hover {
+  transform: scale(1.1);
+  box-shadow: 0 6px 20px rgba(214, 36, 159, 0.6);
+}
+
 @media (max-width: 640px) {
   .whatsapp-float {
     width: 50px;
     height: 50px;
     bottom: 15px;
+    right: 15px;
+  }
+
+  .instagram-float {
+    width: 50px;
+    height: 50px;
+    bottom: 75px;
     right: 15px;
   }
 }


### PR DESCRIPTION
## Summary
- add an Instagram floating action button next to the existing WhatsApp shortcut on static entry pages
- style the new button to mirror the WhatsApp CTA while matching Instagram brand colors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dee516545c832da6a179d9daedf889