### PR TITLE
Fix untranslated strings on homepage

### DIFF
--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -19,17 +19,17 @@ if (!accessKey) {
 
 const onSubmit = async (event) => {
   event.preventDefault();
-  setResult('Envoi en cours...');
+  setResult(t('contact.status.sending'));
 
   if (!accessKey) {
-    setResult('Clé Web3Forms absente. Définis VITE_WEB3FORMS_ACCESS_KEY dans .env/hébergeur puis rebuild.');
+    setResult(t('contact.status.missingKey'));
     return;
   }
 
   // (Optionnel) Valider le format UUID v4
   const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
   if (!uuidRegex.test(accessKey)) {
-    setResult('Clé Web3Forms invalide (doit être un UUID).');
+    setResult(t('contact.status.invalidKey'));
     return;
   }
 
@@ -52,7 +52,7 @@ const onSubmit = async (event) => {
       });
       const data = await response.json();
       if (data.success) {
-        setResult('Formulaire envoyé avec succès !');
+        setResult(t('contact.status.success'));
         event.target.reset();
       } else {
         console.log('Error', data);
@@ -60,7 +60,7 @@ const onSubmit = async (event) => {
       }
     } catch (error) {
       console.error('Network Error', error);
-      setResult('Erreur de réseau. Veuillez réessayer plus tard.');
+      setResult(t('contact.status.networkError'));
     }
   };
 

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -97,12 +97,12 @@ export default function Projects() {
                 </div>
               </div>
               <div>
-                <h4 className="text-lg sm:text-xl font-bold mb-3 sm:mb-4 text-primary-red">Description</h4>
+                <h4 className="text-lg sm:text-xl font-bold mb-3 sm:mb-4 text-primary-red">{t('projects.modal.description')}</h4>
                 <p className="text-gray-300 mb-4 sm:mb-6 text-sm sm:text-base">
                   {selectedProject.description[lang]}
                 </p>
 
-                <h4 className="text-lg sm:text-xl font-bold mb-3 sm:mb-4 text-primary-red">Fonctionnalités</h4>
+                <h4 className="text-lg sm:text-xl font-bold mb-3 sm:mb-4 text-primary-red">{t('projects.modal.features')}</h4>
                 <ul className="space-y-2 mb-4 sm:mb-6">
                   {selectedProject.features[lang].map((feature) => (
                     <li
@@ -117,20 +117,20 @@ export default function Projects() {
 
                 <div className="grid grid-cols-2 gap-4 mb-4 sm:mb-6">
                   <div>
-                    <h5 className="font-bold text-primary-red text-sm sm:text-base">Durée</h5>
+                    <h5 className="font-bold text-primary-red text-sm sm:text-base">{t('projects.modal.duration')}</h5>
                     <p className="text-gray-300 text-sm sm:text-base">
                       {selectedProject.duration[lang]}
                     </p>
                   </div>
                   <div>
-                    <h5 className="font-bold text-primary-red text-sm sm:text-base">Client</h5>
+                    <h5 className="font-bold text-primary-red text-sm sm:text-base">{t('projects.modal.client')}</h5>
                     <p className="text-gray-300 text-sm sm:text-base">
                       {selectedProject.client}
                     </p>
                   </div>
                 </div>
 
-                <h4 className="text-lg sm:text-xl font-bold mb-3 sm:mb-4 text-primary-red">Défis techniques</h4>
+                <h4 className="text-lg sm:text-xl font-bold mb-3 sm:mb-4 text-primary-red">{t('projects.modal.challenges')}</h4>
                 <p className="text-gray-300 mb-4 sm:mb-6 text-sm sm:text-base">
                   {selectedProject.challenges[lang]}
                 </p>
@@ -141,7 +141,7 @@ export default function Projects() {
                   rel="noopener noreferrer"
                   className="bg-primary-red px-4 sm:px-6 py-2 sm:py-3 rounded-lg hover:bg-red-700 transition inline-block text-sm sm:text-base"
                 >
-                  Voir le site <i className="fas fa-external-link-alt ml-2"></i>
+                  {t('projects.modal.visitSite')} <i className="fas fa-external-link-alt ml-2"></i>
                 </a>
                 <button
                   onClick={() => setSelectedProject(null)}

--- a/src/data/translations.js
+++ b/src/data/translations.js
@@ -31,7 +31,18 @@ export const translations = {
         { icon: '✨', title: 'Et + encore', text: 'Bien plus', delay: '1.4s' }
       ]
     },
-    projects: { title: { part1: 'Nos', part2: 'Réalisations' }, close: 'Fermer' },
+    projects: {
+      title: { part1: 'Nos', part2: 'Réalisations' },
+      close: 'Fermer',
+      modal: {
+        description: 'Description',
+        features: 'Fonctionnalités',
+        duration: 'Durée',
+        client: 'Client',
+        challenges: 'Défis techniques',
+        visitSite: 'Voir le site'
+      }
+    },
     contact: {
       title: { part1: 'Nous', part2: 'Contacter' },
       infoTitle: 'Informations de contact',
@@ -41,7 +52,14 @@ export const translations = {
       send: 'Envoyer le message',
       whatsapp: 'WhatsApp: 06 48 45 69 37',
       country: 'France',
-      invalidEmail: 'Adresse e-mail invalide.'
+      invalidEmail: 'Adresse e-mail invalide.',
+      status: {
+        sending: 'Envoi en cours...',
+        missingKey: 'Clé Web3Forms absente. Définis VITE_WEB3FORMS_ACCESS_KEY dans ton environnement puis rebuild.',
+        invalidKey: 'Clé Web3Forms invalide (doit être un UUID).',
+        success: 'Formulaire envoyé avec succès !',
+        networkError: 'Erreur de réseau. Veuillez réessayer plus tard.'
+      }
     },
     footer: {
       description:
@@ -174,7 +192,18 @@ export const translations = {
         { icon: '✨', title: 'And more', text: 'Much more', delay: '1.4s' }
       ]
     },
-    projects: { title: { part1: 'Our', part2: 'Projects' }, close: 'Close' },
+    projects: {
+      title: { part1: 'Our', part2: 'Projects' },
+      close: 'Close',
+      modal: {
+        description: 'Description',
+        features: 'Features',
+        duration: 'Duration',
+        client: 'Client',
+        challenges: 'Technical challenges',
+        visitSite: 'Visit the website'
+      }
+    },
     contact: {
       title: { part1: 'Contact', part2: 'Us' },
       infoTitle: 'Contact Information',
@@ -184,7 +213,14 @@ export const translations = {
       send: 'Send message',
       whatsapp: 'WhatsApp: +33 6 48 45 69 37',
       country: 'France',
-      invalidEmail: 'Invalid email address.'
+      invalidEmail: 'Invalid email address.',
+      status: {
+        sending: 'Sending...',
+        missingKey: 'Web3Forms key missing. Set VITE_WEB3FORMS_ACCESS_KEY in your environment and rebuild.',
+        invalidKey: 'Invalid Web3Forms key (must be a UUID).',
+        success: 'Form successfully sent!',
+        networkError: 'Network error. Please try again later.'
+      }
     },
     footer: {
       description:


### PR DESCRIPTION
## Summary
- add missing translation entries for the project modal and contact form status messages
- update the projects and contact components to rely on the localized strings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e01b483854832db83e4ed65a144df8